### PR TITLE
Reduce database queries

### DIFF
--- a/translations/utils.py
+++ b/translations/utils.py
@@ -111,11 +111,14 @@ def _get_relations_hierarchy(*relations):
 
 def _get_entity_details(entity):
     """Return the iteration and type details of an entity."""
-    error_message = '`{}` is neither {} nor {}.'.format(
-        entity,
-        'a model instance',
-        'an iterable of model instances',
-    )
+
+    def error_message():
+        # Lazy in case str(entity) performs database queries
+        return '`{}` is neither {} nor {}.'.format(
+            entity,
+            'a model instance',
+            'an iterable of model instances',
+        )
 
     if isinstance(entity, models.Model):
         model = type(entity)
@@ -125,12 +128,12 @@ def _get_entity_details(entity):
             if isinstance(entity[0], models.Model):
                 model = type(entity[0])
             else:
-                raise TypeError(error_message)
+                raise TypeError(error_message())
         else:
             model = None
         iterable = True
     else:
-        raise TypeError(error_message)
+        raise TypeError(error_message())
 
     return (iterable, model)
 

--- a/translations/utils.py
+++ b/translations/utils.py
@@ -113,7 +113,8 @@ def _get_relations_hierarchy(*relations):
 def _get_entity_details(entity):
     """Return the iteration and type details of an entity."""
 
-    error_message = SimpleLazyObject(lambda: '`{}` is neither {} nor {}.'.format(
+    error_message = SimpleLazyObject(
+        lambda: '`{}` is neither {} nor {}.'.format(
             entity,
             'a model instance',
             'an iterable of model instances',

--- a/translations/utils.py
+++ b/translations/utils.py
@@ -5,6 +5,7 @@ from django.db.models.query import prefetch_related_objects
 from django.db.models.constants import LOOKUP_SEP
 from django.core.exceptions import FieldError
 from django.contrib.contenttypes.models import ContentType
+from django.utils.functional import SimpleLazyObject
 
 import translations.models
 
@@ -112,13 +113,12 @@ def _get_relations_hierarchy(*relations):
 def _get_entity_details(entity):
     """Return the iteration and type details of an entity."""
 
-    def error_message():
-        # Lazy in case str(entity) performs database queries
-        return '`{}` is neither {} nor {}.'.format(
+    error_message = SimpleLazyObject(lambda: '`{}` is neither {} nor {}.'.format(
             entity,
             'a model instance',
             'an iterable of model instances',
         )
+    )
 
     if isinstance(entity, models.Model):
         model = type(entity)
@@ -128,12 +128,12 @@ def _get_entity_details(entity):
             if isinstance(entity[0], models.Model):
                 model = type(entity[0])
             else:
-                raise TypeError(error_message())
+                raise TypeError(error_message)
         else:
             model = None
         iterable = True
     else:
-        raise TypeError(error_message())
+        raise TypeError(error_message)
 
     return (iterable, model)
 


### PR DESCRIPTION
Models may follow relations in their `__str__` methods – save creating this error message and calling it unless we actually need to emit an exception, so that we don't need to prefetch/select related, or perform N+1 on demand queries.
