### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 
 git:
   depth: 3


### PR DESCRIPTION
This PR updates the Travis configuration to use Xenial where SQLite >= 3.8.3 is available – a requirement of Django.

This PR fixes the build for #60 and #61, and should be merged before they are.
