### PR TITLE
Add CI in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Lint & Test
+name: Main
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,4 +54,33 @@ jobs:
       run: |
         python project/manage.py test -v 3
 
+  docs-test:
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        django-version: ["2.2", "3.0", "3.1", "3.2"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Dependencies
+      run: |
+        pip install django~=${{ matrix.django-version }}.0 djangorestframework~=3.0 sphinx
+
+    - name: Setup Tests
+      run: |
+        python create.py
+        python config.py
+
+    - name: Run Tests
+      run: |
+        make --directory docs doctest
+
   # TODO: deployment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,57 @@
+name: Lint & Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+
+    - name: Install Dependencies
+      run: |
+        pip install flake8~=3.0
+
+    - name: Run Flake8
+      run: |
+        flake8
+
+  test:
+    strategy:
+      matrix:
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        django-version: ["2.2", "3.0", "3.1", "3.2"]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Dependencies
+      run: |
+        pip install django~=${{ matrix.django-version }}.0 djangorestframework~=3.0
+
+    - name: Setup Tests
+      run: |
+        python create.py
+
+    - name: Run Tests
+      run: |
+        python project/manage.py test -v 3
+
+  # TODO: deployment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,4 +83,62 @@ jobs:
       run: |
         make --directory docs doctest
 
-  # TODO: deployment
+  deploy-docs:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [lint, test, docs-test]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.6"
+
+    - name: Install Dependencies
+      run: |
+        pip install django~=${{ matrix.django-version }}.0 djangorestframework~=3.0 sphinx
+
+    - name: Configure
+      run: |
+        python config.py
+
+    - name: Build docs
+      run: |
+        make --directory docs html
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build/html
+
+  deploy-pypi:
+    if: github.event_name == 'push' && github.ref_type == 'tag'
+    needs: [lint, test, docs-test]
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.6"
+
+    - name: Configure
+      run: |
+        python config.py
+
+    - name: Build package
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This offers a potential replacement for Travis by using GitHub Actions.

Note: the deployment stages are untested and will require configuration of at least a PyPI token.
Deployment is converted based on what I'm inferring is desired from what it looks like Travis is doing, though I've not dug deeply into what Travis actually does.
Deployment here is intended to run on tags only and then only if all the checks pass. There might be a better way to spell this (with split workflows) and/or you might want to separate them out to run after releases are created in GitHub for example.

See https://github.com/PeterJCLaw/django-translations/pull/1 for validation of the lint & tests parts of the action.

There's no validation of Django 4 here as that turns out to error still; I'll put up a separate PR (https://github.com/PeterJCLaw/django-translations/pull/2) for that.